### PR TITLE
fix: number macro/tap dance slots from 0

### DIFF
--- a/src/components/keymap/config/keycodeTiles.tsx
+++ b/src/components/keymap/config/keycodeTiles.tsx
@@ -157,7 +157,7 @@ export function SlotTileGrid({
           title={entry.title ?? entry.qmkId}
           onClick={() => onPick(entry)}
         >
-          {j + 1}
+          {j}
           {configured?.[j] && (
             <span
               className="absolute top-1 right-1 size-1.5 rounded-full bg-white"


### PR DESCRIPTION
## Summary
- In the quick-config 自定义按键 (Custom Keys) tab, the macro and Tap Dance slot grid displayed labels starting at 1, off by one from the underlying 0-indexed slot values used elsewhere in the protocol.
- `SlotTileGrid` (shared by both the Macros and Tap Dance cards) now renders slot numbers starting at 0.

## Test plan
- [ ] Open 快捷配置 → 自定义按键 and verify the Macro and Tap Dance slot tiles are numbered starting at 0.