### PR TITLE
fix: point config-editor back button up instead of left

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,7 +214,7 @@ function App() {
                 nav.navigateBack();
               }
             }}
-            icon={nav.returnTo !== null ? "mdi:arrow-left" : "mdi:close"}
+            icon={nav.returnTo !== null ? "mdi:arrow-up" : "mdi:close"}
             label={nav.returnTo !== null ? t("navBackToKeymap") : t("navBackToNewHome")}
             active
           />


### PR DESCRIPTION
## Summary
- The corner back button on the macro/tap-dance editor pages (reached via 快捷配置's "编辑" link) used a left arrow, but the actual transition animates the page upward back to the keyboard config page. Changed the icon from `mdi:arrow-left` to `mdi:arrow-up` to match.

## Test plan
- [ ] Manually verify in browser: navigate to 快捷配置 → 编辑 macro/tap dance → confirm corner button now shows an up arrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)