### PR TITLE
Unify encoder knob display between editor and preview

### DIFF
--- a/src/components/keymap/layout/KeyboardLayoutEditor.tsx
+++ b/src/components/keymap/layout/KeyboardLayoutEditor.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@iconify/react";
 import {
   Fragment,
   useEffect,
@@ -400,6 +401,7 @@ export function KeyboardLayoutEditor({
               </span>
               {press && (
                 <span className="knob-row knob-row-press">
+                  <Icon icon="mdi:gesture-tap-button" className="encoder-dir" aria-hidden="true" />
                   <KeycapFace qmkId={keyboard.getKey(layer, press.key.row, press.key.col)} />
                 </span>
               )}

--- a/src/components/keymap/layout/KeyboardLayoutPreview.tsx
+++ b/src/components/keymap/layout/KeyboardLayoutPreview.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@iconify/react";
 import {
   useMemo,
   useState,
@@ -314,19 +315,23 @@ export function KeyboardLayoutPreview({
             >
               <span className="knob-row">
                 <span className="encoder-dir">↺</span>
+                <KeycapFace qmkId={keyboard.getEncoder(layer, index, 0)} />
               </span>
               {press && (
                 <span className="knob-row knob-row-press">
+                  <Icon icon="mdi:gesture-tap-button" className="encoder-dir" aria-hidden="true" />
                   <KeycapFace qmkId={keyboard.getKey(layer, press.key.row, press.key.col)} />
                 </span>
               )}
               <span className="knob-row">
                 <span className="encoder-dir">↻</span>
+                <KeycapFace qmkId={keyboard.getEncoder(layer, index, 1)} />
               </span>
             </div>
           );
         })}
         {looseEncoders.map(({ encoder, shiftX, shiftY }) => {
+          const qmkId = keyboard.getEncoder(layer, encoder.index, encoder.direction);
           const isSelected =
             menu?.target.kind === "encoder" &&
             menu.target.index === encoder.index &&
@@ -345,6 +350,7 @@ export function KeyboardLayoutPreview({
               style={shapeStyle(encoder, shiftX, shiftY, PITCH, inset, plateMargin)}
             >
               <span className="encoder-dir">{encoder.direction === 1 ? "↻" : "↺"}</span>
+              <KeycapFace qmkId={qmkId} />
             </div>
           );
         })}

--- a/src/index.css
+++ b/src/index.css
@@ -1487,20 +1487,11 @@ input[type="number"].input,
   height: calc(0.9rem * var(--key-font-scale, 1));
 }
 
-/* 按下功能所在的中间行:旋钮的「面」是按下、「圈」是旋转,所以按下用接近普通键帽
-   的字号占据圆心,两个旋转方向缩在上下两条边上。只有板子把旋钮轴向开关接进矩阵
-   时才会出现这一行(见 knobGrouping.ts 的 press 推断)。 */
+/* 按下功能所在的中间行:与左旋/右旋两行共用同一套字号(见上方
+   `.encoder-knob`/`.encoder-knob .key-icon`),三行文字/图标大小保持一致。只有
+   板子把旋钮轴向开关接进矩阵时才会出现这一行(见 knobGrouping.ts 的 press 推断)。 */
 .keyboard-layout .encoder-knob-press {
   gap: 0;
-}
-
-.keyboard-layout .encoder-knob .knob-row-press {
-  font-size: calc(0.7rem * var(--key-font-scale, 1));
-}
-
-.keyboard-layout .encoder-knob .knob-row-press .key-icon {
-  width: calc(1.15rem * var(--key-font-scale, 1));
-  height: calc(1.15rem * var(--key-font-scale, 1));
 }
 
 /* 线稿(wireframe) 风格：键帽/旋钮只描边、不填充 —— 4 态立体感枚举(PreviewStyle)


### PR DESCRIPTION
## Summary
- `KeyboardLayoutPreview` was missing the per-direction `KeycapFace` labels on encoder knobs that `KeyboardLayoutEditor` already rendered (for both grouped knob widgets and loose single-direction encoders); unified on the editor's behavior.
- Added a "press" icon (`mdi:gesture-tap-button`) to the knob's press row, matching the existing rotate-left/rotate-right icons.
- Removed the press row's oversized font-size/icon-size CSS overrides so the ccw/press/cw rows all render text and icons at the same size.

## Test plan
- [x] `pnpm build` (tsc -b + vite build) passes
- [x] Visually verify knob labels/icons in the browser on a board with a knob press switch