### PR TITLE
fix: size macro key picker to device's actual macro count

### DIFF
--- a/src/protocol/keyboard.ts
+++ b/src/protocol/keyboard.ts
@@ -13,6 +13,7 @@ import {
   serialize as kcSerialize,
   setCustomKeycodes,
   setKeycodeVersion,
+  setMacroCount,
   setTapDanceCount,
   type CustomKeycode,
 } from "./keycodes.ts";
@@ -908,6 +909,7 @@ export class Keyboard {
   private async reloadMacros(): Promise<void> {
     const countData = await this.transport.send(new Uint8Array([C.CMD_VIA_MACRO_GET_COUNT]), 20);
     this.macroCount = countData[1];
+    setMacroCount(this.macroCount);
 
     const sizeData = await this.transport.send(new Uint8Array([C.CMD_VIA_MACRO_GET_BUFFER_SIZE]), 20);
     this.macroMemory = new DataView(sizeData.buffer, sizeData.byteOffset, sizeData.byteLength).getUint16(1, false);

--- a/src/protocol/keycodes.ts
+++ b/src/protocol/keycodes.ts
@@ -1072,15 +1072,14 @@ export const KEYCODES_QUANTUM: KeycodeDef[] = [
   ]),
 ];
 
-function macroKeycodes(): KeycodeDef[] {
-  const defs: KeycodeDef[] = [];
-  for (let x = 0; x < 16; x++) {
-    defs.push({ qmkId: `M${x}`, label: `M${x}` });
-  }
-  return defs;
-}
-
-export const KEYCODES_MACRO: KeycodeDef[] = macroKeycodes();
+/**
+ * The connected device's macro slots, M0..M(macroCount-1) — populated by
+ * `setMacroCount` once `Keyboard.reload()` knows the device's macro count
+ * (see `reloadMacros`), same live-binding pattern as `setTapDanceCount`
+ * below. Empty (and the "Macros" category empty) until then, rather than a
+ * fixed 16 that would drift from whatever the device actually reports.
+ */
+export const KEYCODES_MACRO: KeycodeDef[] = [];
 
 export const KEYCODES_LIGHTING: KeycodeDef[] = table([
   ["BL_TOGG", "BL\nToggle"],
@@ -1705,6 +1704,19 @@ export function setTapDanceCount(count: number): void {
     const qmkId = `TD(${i})`;
     deviceLabelByQmkId.set(qmkId, `TD${i}`);
     tapDanceDefsCache.push({ qmkId, label: `TD${i}` });
+  }
+}
+
+/**
+ * Registers how many macro slots the device exposes, as M0..M(count-1).
+ * Mutates {@link KEYCODES_MACRO} in place (rather than reassigning it) so the
+ * "Macros" entry already captured into `KEYCODE_CATEGORIES` at module load
+ * keeps seeing the live list.
+ */
+export function setMacroCount(count: number): void {
+  KEYCODES_MACRO.length = 0;
+  for (let x = 0; x < count; x++) {
+    KEYCODES_MACRO.push({ qmkId: `M${x}`, label: `M${x}` });
   }
 }
 


### PR DESCRIPTION
## Summary
- The 自定义按键 quick-config tab's Macro card listed a hardcoded M0–M15 (16 slots) regardless of what the connected board reports as `keyboard.macroCount`, unlike Tap Dance which was already kept live.
- Boards with fewer macro slots exposed clickable phantom keys with no backing storage; boards with more couldn't reach the extra slots from the picker.
- Added `setMacroCount()` in `keycodes.ts` (mirrors the existing `setTapDanceCount` pattern) and call it from `Keyboard.reloadMacros()` right after `macroCount` is known.

## Test plan
- [x] `pnpm build`
- [x] `pnpm test`
- [ ] Manually verify on a real device that the Macro card's tile count matches its actual macro slot count

🤖 Generated with [Claude Code](https://claude.com/claude-code)